### PR TITLE
Storage Upgrades

### DIFF
--- a/src/assets/scss/info-page.scss
+++ b/src/assets/scss/info-page.scss
@@ -31,9 +31,14 @@ h1 {
   box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.7);
 }
 
-h2, p + p { margin-top: 1rem; }
+h2, h3, p + p { margin-top: 1rem; }
 
 h2 { margin-bottom: 0.5rem; }
+
+h3 {
+  margin-top: 1.5rem;
+  font-size: 1.25rem;
+}
 
 ul {
   margin: 1rem 0rem 1rem 1.5rem;

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -210,6 +210,22 @@ button {
   }
 }
 
+.pill-link {
+  display: inline-block;
+  padding: 0.5rem 1.25rem;
+  background-color: vars.$secondary;
+  color: vars.$white;
+  border-radius: vars.$border-radius-lg;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.3s;
+
+  &:hover {
+    background-color: vars.$secondary-dark;
+    text-decoration: none;
+  }
+}
+
 @media (max-width: #{vars.$breakpoint-mobile}) {
   .hide-mobile {
     display: none;

--- a/src/components/StoragePage.vue
+++ b/src/components/StoragePage.vue
@@ -22,25 +22,30 @@
     </p>
 
     <ul>
-      <li><strong>A heavy-duty lock</strong> - a U-lock or chain lock rated against angle grinders (see our
-        <router-link to="/gear-guide">Gear Guide</router-link>)</li>
-      <li><strong>A weather cover</strong> - motorcycle covers work great for cargo bikes and keep
-        rain, sun, and dust off</li>
-      <li><strong>A visible, well-lit spot</strong> - thieves prefer to work unobserved</li>
+      <li>
+        <strong>A Heavy-Duty Lock</strong> - a U-lock or chain lock rated against angle grinders (see our
+        <router-link to="/gear-guide">Gear Guide</router-link>)
+      </li>
+      <li>
+        <strong>A Weather Cover</strong> - motorcycle covers work great for cargo bikes and keep
+        rain, sun, and dust off, and make it blend in and look less valuable
+      </li>
+      <li>
+        <strong>A Visible, Well-Lit Spot</strong> - thieves prefer to work unobserved - so a well-lit
+        spot can really help
+      </li>
+      <li>
+        <strong>A GPS Tracker</strong> - a hidden tracker like an AirTag can help recover a
+        stolen bike (see <a href="https://www.nytimes.com/wirecutter/reviews/best-bluetooth-tracker/"
+        target="_blank" rel="noopener">Wirecutter's Bluetooth tracker guide</a>)
+      </li>
     </ul>
 
     <p>
-      For a deep dive on outdoor parking options, including tips on short-stop locking, check out
+      For a deep dive on outdoor parking options, including tips on locking during short stops,
+      check out
       <a href="https://bunchbike.com/blogs/the-bunch-blog/how-should-i-lock-up-my-bike"
         target="_blank" rel="noopener">Bunch Bike's guide on how to lock up your bike</a>.
-    </p>
-
-    <h2>Outdoor Storage For Cargo Bikes</h2>
-
-    <p>
-      Cargo bikes are too big for most apartments, but that doesn't mean you need a garage.
-      Plenty of families store cargo bikes in alleys, on patios, or on sidewalks with a
-      good lock and a cover.
     </p>
 
     <p>
@@ -48,6 +53,23 @@
       <a href="https://youtu.be/r-fWnbTkuaQ?si=92wLmDFhAng-eSo3&t=440"
         target="_blank" rel="noopener">a great video with tips from her professional
         background in criminology</a> on keeping your bike safe outside.
+    </p>
+
+    <h2>Theft Protection &amp; Insurance</h2>
+
+    <p>
+      Beyond a good lock, some owners add extra layers of protection. A motorcycle alarm
+      can deter opportunistic thieves, and a hidden GPS tracker like an AirTag can help
+      recover a stolen bike.
+    </p>
+
+    <p>
+      Bike-specific insurance is also worth considering, especially for pricier cargo bikes
+      and eBikes. It can cover theft, damage, and liability, giving you peace of mind whether
+      you store indoors or out. See
+      <a href="https://www.cyclingweekly.com/news/latest-news/everything-you-need-to-know-about-e-bike-insurance-483684"
+        target="_blank" rel="noopener">Cycling Weekly's eBike insurance guide</a>
+      for a good overview of what's available.
     </p>
 
     <h2>Indoor Storage</h2>

--- a/src/components/assessment/BikeAssessment.vue
+++ b/src/components/assessment/BikeAssessment.vue
@@ -77,8 +77,8 @@
           <bike-recommendation
             :recommendation-details="recommendationDetails"
             :all-bike-types="bikeTypeDetails"
-            :ideal-bike-type="idealBikeType"
-            :storage-constrained="storage === 'upper-floor' || idealBikeType !== null"
+            :alternate-bike-type="alternateBikeType"
+            :storage-constrained="alternateBikeType !== null"
             :recommended-bike-type="recommendation"
             :savings-amount="stickysavings"
             @bike-change="handleBikeChange"
@@ -185,7 +185,7 @@ const prefersStability = ref(false);
 watch(transportationNeeds, () => {}, { deep: true });
 watch(geography, () => {}, { deep: true });
 const recommendation = ref<BikeTypeId | ''>('');
-const idealBikeType = ref<BikeTypeId | null>(null);
+const alternateBikeType = ref<BikeTypeId | null>(null);
 
 watch(recommendation, (bikeTypeId) => {
   if (bikeTypeId) {
@@ -343,7 +343,7 @@ function calculateRecommendation() {
   });
 
   recommendation.value = typeRecommender.bikeType;
-  idealBikeType.value = typeRecommender.idealBikeType;
+  alternateBikeType.value = typeRecommender.alternateBikeType;
 
   // Set recommendation details
   setRecommendationDetails();
@@ -381,7 +381,7 @@ function setRecommendationDetails() {
 
 // Handle bike change from the dropdown
 function handleBikeChange(bikeType: BikeTypeId | null) {
-  idealBikeType.value = null;
+  alternateBikeType.value = null;
 
   if (!bikeType) {
     // Restore original bike costs and details for the recommended bike
@@ -404,7 +404,7 @@ function handleBikeChange(bikeType: BikeTypeId | null) {
 // Function to update URL with bike recommendation
 function updateUrlWithRecommendation(bikeType: BikeTypeId) {
   const query: Record<string, string> = {};
-  if (idealBikeType.value) query.ideal = idealBikeType.value;
+  if (alternateBikeType.value) query.ideal = alternateBikeType.value;
   if (assessmentProfile.value) query.form = encodeProfile(assessmentProfile.value);
   router.replace({ name: 'BikeResult', params: { type: bikeType }, query });
 }
@@ -432,7 +432,7 @@ function restartAssessment() {
   fitnessLevel.value = '';
   prefersStability.value = false;
   recommendation.value = '';
-  idealBikeType.value = null;
+  alternateBikeType.value = null;
 
   clearChoicesFromSession();
 
@@ -450,7 +450,7 @@ onBeforeRouteUpdate((to) => {
     fitnessLevel.value = '';
     prefersStability.value = false;
     recommendation.value = '';
-    idealBikeType.value = null;
+    alternateBikeType.value = null;
     showStickyHeader.value = false;
     stickysavings.value = 0;
     stickyCarLabel.value = '';
@@ -481,7 +481,7 @@ onMounted(() => {
     // Restore ideal bike type from query param if present
     const idealParam = route.query.ideal;
     if (typeof idealParam === 'string' && Object.keys(bikeTypeDetails).includes(idealParam)) {
-      idealBikeType.value = idealParam as BikeTypeId;
+      alternateBikeType.value = idealParam as BikeTypeId;
     }
 
     // Restore profile from query param, falling back to session storage

--- a/src/components/assessment/BikeAssessment.vue
+++ b/src/components/assessment/BikeAssessment.vue
@@ -57,7 +57,7 @@
             <span class="sticky-bike">{{ recommendationDetails.title }}</span>
             <span class="sticky-separator">vs</span>
             <span class="sticky-car">{{ stickyCarLabel }}</span>
-            <span class="sticky-savings">{{ formatCurrency(stickysavings) }} savings</span>
+            <span class="sticky-savings">{{ Currency.format(stickysavings) }} savings</span>
           </div>
 
           <div class="top-row">
@@ -152,6 +152,7 @@ import { SiteName } from '../../constants/pageMeta';
 import { TransportationNeedOptions, GeographyOptions, FitnessOptions, StorageOptions } from '../../constants/assessmentOptions';
 import BikeTypeRecommender from '../../services/BikeTypeRecommender';
 import { encodeProfile, decodeProfile } from '../../services/AssessmentForm';
+import Currency from '../../utils/currency';
 import type { AssessmentProfile, BikeTypeId, BikeType, TransportationNeeds, Geography, FitnessLevel, StorageType, ChoiceGroup, CostComparison } from '../../types';
 
 const props = defineProps({
@@ -461,13 +462,6 @@ onBeforeRouteUpdate((to) => {
   }
 });
 
-function formatCurrency(value: number) {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    maximumFractionDigits: 0
-  }).format(value);
-}
 
 // Initialize based on route param /bike/:type (need to be after all functions are defined)
 onMounted(() => {

--- a/src/components/assessment/BikeRecommendation.vue
+++ b/src/components/assessment/BikeRecommendation.vue
@@ -2,7 +2,9 @@
   <div>
     <div v-if="alternateBikeType && allBikeTypes && allBikeTypes[alternateBikeType as BikeTypeId]" class="alternate-note">
       <h4 class="alternate-note-heading">Absolutely Can't Store Outside?</h4>
-      <img :src="allBikeTypes[alternateBikeType as BikeTypeId].image" :alt="allBikeTypes[alternateBikeType as BikeTypeId].title" class="alternate-note-image">
+      <a :href="'/bike/' + alternateBikeType" target="_blank" rel="noopener" aria-hidden="true" tabindex="-1">
+        <img :src="allBikeTypes[alternateBikeType as BikeTypeId].image" :alt="allBikeTypes[alternateBikeType as BikeTypeId].title" class="alternate-note-image">
+      </a>
       <div class="alternate-note-body">
         <p>
           You can store a large cargo bike outside with a cover and a great lock, but if you
@@ -14,8 +16,8 @@
           instead. It's much easier to store indoors!
         </p>
         <p class="alternate-note-tip">
-          <router-link to="/storage" class="alternate-link">
-            Learn more about bike storage options.
+          <router-link to="/storage" target="_blank" class="pill-link">
+            Learn Bike Storage Tips
           </router-link>
         </p>
       </div>
@@ -295,8 +297,7 @@ const alternateArticle = computed(() => {
 }
 
 .alternate-note-tip {
-  margin-top: 0.5rem !important;
-  font-size: 0.85rem !important;
+  margin-top: 0.75rem !important;
 }
 
 .storage-tip {
@@ -364,10 +365,12 @@ const alternateArticle = computed(() => {
 .alternate-note-image {
   float: left;
   width: auto;
-  height: 80px;
+  height: 6rem;
   border-radius: 8px;
   margin-right: 1rem;
   margin-bottom: 0.25rem;
+  background-color: vars.$white;
+  padding: 0.25rem;
 }
 
 @media (min-width: #{vars.$breakpoint-mobile-up}) {

--- a/src/components/assessment/BikeRecommendation.vue
+++ b/src/components/assessment/BikeRecommendation.vue
@@ -7,8 +7,9 @@
       </a>
       <div class="alternate-note-body">
         <p>
-          You can store a large cargo bike outside with a cover and a great lock, but if you
-          absolutely can't, check out
+          You can store a large cargo bike outside with a cover and a great lock — some
+          owners also add a GPS tracker, motorcycle alarm, or bike-specific insurance for
+          extra peace of mind. But if you absolutely can't store outside, check out
           {{ alternateArticle }}
           <a :href="'/bike/' + alternateBikeType" target="_blank" rel="noopener" class="alternate-link">
             <strong>{{ allBikeTypes[alternateBikeType as BikeTypeId].title }}</strong>

--- a/src/components/assessment/BikeRecommendation.vue
+++ b/src/components/assessment/BikeRecommendation.vue
@@ -1,21 +1,20 @@
 <template>
   <div>
-    <div v-if="idealBikeType && allBikeTypes && allBikeTypes[idealBikeType as BikeTypeId]" class="ideal-note">
-      <h4 class="ideal-note-heading">Your Ideal Bike Might Be Too Hard To Store</h4>
-      <img :src="allBikeTypes[idealBikeType as BikeTypeId].image" :alt="allBikeTypes[idealBikeType as BikeTypeId].title" class="ideal-note-image">
-      <div class="ideal-note-body">
+    <div v-if="alternateBikeType && allBikeTypes && allBikeTypes[alternateBikeType as BikeTypeId]" class="alternate-note">
+      <h4 class="alternate-note-heading">Absolutely Can't Store Outside?</h4>
+      <img :src="allBikeTypes[alternateBikeType as BikeTypeId].image" :alt="allBikeTypes[alternateBikeType as BikeTypeId].title" class="alternate-note-image">
+      <div class="alternate-note-body">
         <p>
-          {{ idealArticle }}
-          <a :href="'/bike/' + idealBikeType" target="_blank" rel="noopener" class="ideal-link">
-            <strong>{{ allBikeTypes[idealBikeType as BikeTypeId].title }}</strong>
+          You can store a large cargo bike outside with a cover and a great lock, but if you
+          absolutely can't, check out
+          {{ alternateArticle }}
+          <a :href="'/bike/' + alternateBikeType" target="_blank" rel="noopener" class="alternate-link">
+            <strong>{{ allBikeTypes[alternateBikeType as BikeTypeId].title }}</strong>
           </a>
-          would be the ideal fit for your needs, but based on your storage situation
-          <strong>we've recommended a more practical option below.</strong>
-          Keep it in mind if your storage changes down the road!
+          instead. It's much easier to store indoors!
         </p>
-        <p class="ideal-note-tip">
-          However, some people do store cargo bikes outside under motorcycle covers!
-          <router-link to="/storage" class="ideal-link">
+        <p class="alternate-note-tip">
+          <router-link to="/storage" class="alternate-link">
             Learn more about bike storage options.
           </router-link>
         </p>
@@ -87,22 +86,22 @@ import type { BikeType, BikeTypeId } from '../../types';
 const props = withDefaults(defineProps<{
   recommendationDetails: BikeType;
   allBikeTypes?: Record<BikeTypeId, BikeType> | null;
-  idealBikeType?: string | null;
+  alternateBikeType?: string | null;
   storageConstrained?: boolean;
   recommendedBikeType?: string;
   savingsAmount?: number;
 }>(), {
   allBikeTypes: null,
-  idealBikeType: null,
+  alternateBikeType: null,
   storageConstrained: false,
   recommendedBikeType: '',
   savingsAmount: 0
 });
 
-const idealArticle = computed(() => {
-  if (!props.idealBikeType || !props.allBikeTypes?.[props.idealBikeType as BikeTypeId]) return 'A';
-  const title = props.allBikeTypes[props.idealBikeType as BikeTypeId].title;
-  return /^[aeiou]/i.test(title) ? 'An' : 'A';
+const alternateArticle = computed(() => {
+  if (!props.alternateBikeType || !props.allBikeTypes?.[props.alternateBikeType as BikeTypeId]) return 'a';
+  const title = props.allBikeTypes[props.alternateBikeType as BikeTypeId].title;
+  return /^[aeiou]/i.test(title) ? 'an' : 'a';
 });
 </script>
 
@@ -268,7 +267,7 @@ const idealArticle = computed(() => {
   font-size: 0.8rem;
 }
 
-.ideal-note {
+.alternate-note {
   background-color: vars.$secondary-light;
   border-radius: 8px;
   padding: 1rem 1.5rem;
@@ -284,18 +283,18 @@ const idealArticle = computed(() => {
   }
 }
 
-.ideal-note-heading {
+.alternate-note-heading {
   color: vars.$secondary-dark;
   font-size: 1rem;
   margin-bottom: 1rem;
 }
 
-.ideal-note-body {
+.alternate-note-body {
   flex: 1;
   min-width: 0;
 }
 
-.ideal-note-tip {
+.alternate-note-tip {
   margin-top: 0.5rem !important;
   font-size: 0.85rem !important;
 }
@@ -353,7 +352,7 @@ const idealArticle = computed(() => {
   }
 }
 
-.ideal-link {
+.alternate-link {
   color: vars.$secondary-dark;
   text-decoration: underline;
 
@@ -362,7 +361,7 @@ const idealArticle = computed(() => {
   }
 }
 
-.ideal-note-image {
+.alternate-note-image {
   float: left;
   width: auto;
   height: 80px;
@@ -396,7 +395,7 @@ const idealArticle = computed(() => {
     align-self: start;
   }
 
-  .ideal-note {
+  .alternate-note {
     display: flex;
     align-items: flex-start;
     gap: 0 1.5rem;
@@ -404,11 +403,11 @@ const idealArticle = computed(() => {
     justify-content: center;
   }
 
-  .ideal-note-heading {
+  .alternate-note-heading {
     width: 100%;
   }
 
-  .ideal-note-image {
+  .alternate-note-image {
     float: none;
     margin: auto;
   }

--- a/src/components/assessment/CostComparisonTable.vue
+++ b/src/components/assessment/CostComparisonTable.vue
@@ -8,23 +8,23 @@
       <div class="cost-breakdown">
         <div class="cost-item">
           <span class="cost-label">Initial Purchase</span>
-          <span class="cost-value">{{ formatCurrency(costs.bike.purchase) }}</span>
+          <span class="cost-value">{{ Currency.format(costs.bike.purchase) }}</span>
         </div>
         <div class="cost-item">
           <span class="cost-label">Annual Maintenance</span>
-          <span class="cost-value">{{ formatCurrency(costs.bike.maintenance) }}</span>
+          <span class="cost-value">{{ Currency.format(costs.bike.maintenance) }}</span>
         </div>
         <div class="cost-item">
           <span class="cost-label">Annual "Fuel" Cost</span>
-          <span class="cost-value">{{ formatCurrency(costs.bike.fuel) }}</span>
+          <span class="cost-value">{{ Currency.format(costs.bike.fuel) }}</span>
         </div>
         <div class="cost-item">
           <span class="cost-label">Annual Insurance</span>
-          <span class="cost-value">{{ formatCurrency(costs.bike.insurance) }}</span>
+          <span class="cost-value">{{ Currency.format(costs.bike.insurance) }}</span>
         </div>
         <div class="cost-item total">
           <span class="cost-label">5-Year Total Cost</span>
-          <span class="cost-value">{{ formatCurrency(bikeTotalCost) }}</span>
+          <span class="cost-value">{{ Currency.format(bikeTotalCost) }}</span>
         </div>
       </div>
     </div>
@@ -57,28 +57,28 @@
         <div class="cost-item" v-if="!alreadyOwnsCar">
           <span class="cost-label">Initial Purchase</span>
           <span class="cost-value">
-            {{ formatCurrency(isNew ? CAR_COSTS.purchase : CAR_COSTS.usedPurchase) }}
+            {{ Currency.format(isNew ? CAR_COSTS.purchase : CAR_COSTS.usedPurchase) }}
             <sup class="footnote-link" @click="showFootnote('purchase')">¹</sup>
           </span>
         </div>
         <div class="cost-item">
           <span class="cost-label">Annual Maintenance</span>
           <span class="cost-value">
-            {{ formatCurrency(costs.car.maintenance * (alreadyOwnsCar ? 1 - replacementPercent / 100 : 1)) }}
+            {{ Currency.format(costs.car.maintenance * (alreadyOwnsCar ? 1 - replacementPercent / 100 : 1)) }}
             <sup class="footnote-link" @click="showFootnote('maintenance')">{{ alreadyOwnsCar ? '¹' : '²' }}</sup>
           </span>
           <span v-if="alreadyOwnsCar" class="cost-saving">
-            Save {{ formatCurrency(maintenanceSaving) }}/yr
+            Save {{ Currency.format(maintenanceSaving) }}/yr
           </span>
         </div>
         <div class="cost-item">
           <span class="cost-label">Annual Fuel Cost</span>
           <span class="cost-value">
-            {{ formatCurrency(costs.car.fuel * (alreadyOwnsCar ? 1 - replacementPercent / 100 : 1)) }}
+            {{ Currency.format(costs.car.fuel * (alreadyOwnsCar ? 1 - replacementPercent / 100 : 1)) }}
             <sup class="footnote-link" @click="showFootnote('fuel')">{{ alreadyOwnsCar ? '²' : '³' }}</sup>
           </span>
           <span v-if="alreadyOwnsCar" class="cost-saving">
-            Save {{ formatCurrency(fuelSaving) }}/yr
+            Save {{ Currency.format(fuelSaving) }}/yr
           </span>
         </div>
         <div class="cost-item">
@@ -86,20 +86,20 @@
             {{ alreadyOwnsCar ? 'Mileage-Based Insurance' : 'Annual Insurance' }}
           </span>
           <span class="cost-value">
-            {{ formatCurrency(alreadyOwnsCar ? mileageInsuranceAnnual : costs.car.insurance) }}
+            {{ Currency.format(alreadyOwnsCar ? mileageInsuranceAnnual : costs.car.insurance) }}
             <sup class="footnote-link" @click="showFootnote('insurance')">{{ alreadyOwnsCar ? '³' : '⁴' }}</sup>
           </span>
           <span v-if="alreadyOwnsCar" class="cost-saving">
-            Save {{ formatCurrency(insuranceSaving) }}/yr
+            Save {{ Currency.format(insuranceSaving) }}/yr
           </span>
         </div>
         <div class="cost-item total">
           <span class="cost-label">5-Year Total Cost</span>
-          <span class="cost-value">{{ formatCurrency(carTotalCost) }}</span>
+          <span class="cost-value">{{ Currency.format(carTotalCost) }}</span>
         </div>
         <div v-if="alreadyOwnsCar" class="cost-item total savings-total">
           <span class="cost-label">5-Year Savings</span>
-          <span class="cost-value">{{ formatCurrency(totalAnnualSaving * 5) }}</span>
+          <span class="cost-value">{{ Currency.format(totalAnnualSaving * 5) }}</span>
         </div>
       </div>
     </div>
@@ -113,8 +113,8 @@
     </div>
     <div class="footnote-content">
       <div class="footnote" v-if="activeFootnote === 'purchase' || activeFootnote === 'all'">
-        <p v-if="!isNew"><strong>¹ Used car purchase price:</strong> {{ formatCurrency(CAR_COSTS.usedPurchase) }} average (Cox Automotive, {{ CAR_COSTS.usedPurchaseUpdatedAt }})</p>
-        <p v-else><strong>¹ New car purchase price:</strong> {{ formatCurrency(CAR_COSTS.purchase) }} average (Cox Automotive, {{ CAR_COSTS.purchaseUpdatedAt }})</p>
+        <p v-if="!isNew"><strong>¹ Used car purchase price:</strong> {{ Currency.format(CAR_COSTS.usedPurchase) }} average (Cox Automotive, {{ CAR_COSTS.usedPurchaseUpdatedAt }})</p>
+        <p v-else><strong>¹ New car purchase price:</strong> {{ Currency.format(CAR_COSTS.purchase) }} average (Cox Automotive, {{ CAR_COSTS.purchaseUpdatedAt }})</p>
         <p class="source-link">
           <a :href="isNew ? carCostSources.purchaseSource : carCostSources.usedPurchaseSource" target="_blank">
             Source: Cox Automotive ({{ isNew ? CAR_COSTS.purchaseUpdatedAt : CAR_COSTS.usedPurchaseUpdatedAt }})
@@ -150,7 +150,7 @@
           </p>
         </template>
         <template v-else>
-          <p><strong>⁴ Insurance costs:</strong> {{ formatCurrency(CAR_COSTS.insurance) }}/year average ({{ CAR_COSTS.insuranceUpdatedAt }})</p>
+          <p><strong>⁴ Insurance costs:</strong> {{ Currency.format(CAR_COSTS.insurance) }}/year average ({{ CAR_COSTS.insuranceUpdatedAt }})</p>
           <p class="source-link">
             <a :href="carCostSources.insuranceSource" target="_blank">
               Source: NerdWallet ({{ CAR_COSTS.insuranceUpdatedAt }})
@@ -165,6 +165,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
 import { CAR_COSTS } from '../../constants/bikeCosts';
+import Currency from '../../utils/currency';
 
 const props = defineProps({
   bikeTitle: { type: String, required: true },
@@ -198,13 +199,6 @@ function showFootnote(type: string) {
   showFootnotes.value = true;
 }
 
-function formatCurrency(value: number) {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    maximumFractionDigits: 0
-  }).format(value);
-}
 
 // Per-line annual savings when in "already owns" mode
 const scale = computed(() => props.replacementPercent / 100);

--- a/src/components/assessment/SavingsComparison.vue
+++ b/src/components/assessment/SavingsComparison.vue
@@ -83,7 +83,7 @@
           Your 5-Year Savings
           <anchor-copy-button anchor="savings-total" />
         </h3>
-        <div class="amount">{{ formatCurrency(savingsAmount) }}</div>
+        <div class="amount">{{ Currency.format(savingsAmount) }}</div>
       </div>
       <div class="savings-benefits">
         <h4>What else you could do with this money:</h4>
@@ -92,7 +92,7 @@
             <div class="benefit-emoji">✈️</div>
             <h5>Travel</h5>
             <p>Take {{ Math.round(savingsAmount / IntlVacationCost) }} international vacations</p>
-            <p class="vacation-cost-note">at ~{{ formatCurrency(IntlVacationCost) }} per trip</p>
+            <p class="vacation-cost-note">at ~{{ Currency.format(IntlVacationCost) }} per trip</p>
           </div>
           <div class="benefit-card">
             <div class="benefit-emoji">🏠</div>
@@ -103,10 +103,10 @@
             <div class="benefit-emoji">📈</div>
             <h5>Invest</h5>
             <p>
-              Worth <strong>{{ formatRounded(savings10Year) }} in 10 years</strong> at 7% growth
+              Worth <strong>{{ Currency.formatRounded(savings10Year) }} in 10 years</strong> at 7% growth
             </p>
             <p class="long-term-growth">
-              Or <strong>{{ formatRounded(savings40Year) }} over 40 years</strong>, like in your 401k!
+              Or <strong>{{ Currency.formatRounded(savings40Year) }} over 40 years</strong>, like in your 401k!
             </p>
           </div>
         </div>
@@ -134,6 +134,21 @@
           <strong>Dealing With Tons Of Snow?</strong> Look for bikes with wider, knobby tires
            and fenders to keep salt and slush off your frame.
         </p>
+      </div>
+    </div>
+
+    <div v-if="showStorageTip" class="buying-tips">
+      <div class="buying-tips-icon">🏠</div>
+      <div class="buying-tips-content">
+        <h4>Plan Your Storage</h4>
+        <p>
+          Larger bikes like cargo bikes and longtails need a bit more thought when it comes to
+          storage. A good cover and a sturdy lock make outdoor storage totally viable, and many
+          people store cargo bikes in garages, sheds, or even hallways.
+        </p>
+        <router-link to="/storage" target="_blank" class="find-shops-btn">
+          Learn Bike Storage Tips <span class="chevron-right" aria-hidden="true"></span>
+        </router-link>
       </div>
     </div>
 
@@ -179,7 +194,7 @@
             <div class="bike-option-details">
               <div class="recommendation-pill">Your Recommendation</div>
               <h4>{{ bikeTitle }}</h4>
-              <div class="bike-price">~ {{ formatCurrency(costs.bike.purchase) }}</div>
+              <div class="bike-price">~ {{ Currency.format(costs.bike.purchase) }}</div>
             </div>
           </div>
           <router-link class="bike-option"
@@ -194,7 +209,7 @@
             </div>
             <div class="bike-option-details">
               <h4>{{ type.label }}</h4>
-              <div class="bike-price">~ {{ formatCurrency(BikeTypes[type.value as BikeTypeId].costs.purchase) }}</div>
+              <div class="bike-price">~ {{ Currency.format(BikeTypes[type.value as BikeTypeId].costs.purchase) }}</div>
             </div>
           </router-link>
         </div>
@@ -211,6 +226,8 @@ import { useRoute } from 'vue-router';
 import { CAR_COSTS } from '../../constants/bikeCosts';
 import { BikeTypes } from '../../constants/bikeTypes';
 import { isPlainClick } from '../../utils/navigation';
+import Currency from '../../utils/currency';
+import StorageTip from '../../services/storageTip';
 import type { AssessmentProfile, BikeTypeId } from '../../types';
 
 import AnchorCopyButton from '../AnchorCopyButton.vue';
@@ -357,8 +374,8 @@ const savingsAmount = computed(() => {
   return carTotalCost.value - bikeTotalCost.value;
 });
 
-const savings10Year = computed(() => savingsAmount.value * Math.pow(1 + EstGrowthRate, InvestmentYearsShort));
-const savings40Year = computed(() => savingsAmount.value * Math.pow(1 + EstGrowthRate, InvestmentYearsLong));
+const savings10Year = computed(() => Currency.investmentGrowth(savingsAmount.value, EstGrowthRate, InvestmentYearsShort));
+const savings40Year = computed(() => Currency.investmentGrowth(savingsAmount.value, EstGrowthRate, InvestmentYearsLong));
 
 // Emit savings and car label to parent for sticky header
 const carLabel = computed(() => {
@@ -412,6 +429,12 @@ const availableBikeTypes = computed(() => {
 // The bike type currently shown — comparison selection takes priority over the recommendation
 const displayedBikeType = computed(() => comparisonBike.value || recommendationType.value);
 
+const showStorageTip = computed(() => {
+  const bikeType = displayedBikeType.value;
+  if (!bikeType || !props.profile) return false;
+  return StorageTip.shouldShowBuyingTip(bikeType as BikeTypeId, props.profile.storage);
+});
+
 // Handle bike type change — only do in-page comparison on plain clicks;
 // let Ctrl+Click / Cmd+Click / middle-click navigate normally.
 function handleComparisonClick(event: MouseEvent, bikeType: string) {
@@ -421,28 +444,6 @@ function handleComparisonClick(event: MouseEvent, bikeType: string) {
   emit('bike-change', bikeType);
 }
 
-// Currency formatting helper
-function formatCurrency(value: number) {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    maximumFractionDigits: 0
-  }).format(value);
-}
-
-// Rounds to nearest $1k below $1M, or "$X.XM" above
-function formatRounded(value: number) {
-  if (value >= 1_000_000) {
-    const millions = Math.round(value / 100_000) / 10;
-    const formatted = millions % 1 === 0 ? millions.toFixed(0) : millions.toFixed(1);
-    return '$' + formatted + ' million';
-  }
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    maximumFractionDigits: 0
-  }).format(Math.round(value / 1000) * 1000);
-}
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/assessment/SavingsComparison.vue
+++ b/src/components/assessment/SavingsComparison.vue
@@ -144,7 +144,8 @@
         <p>
           Larger bikes like cargo bikes and longtails need a bit more thought when it comes to
           storage. A good cover and a sturdy lock make outdoor storage totally viable, and many
-          people store cargo bikes in garages, sheds, or even hallways.
+          people store cargo bikes in garages, sheds, or even hallways. Some owners also add a GPS
+          tracker, motorcycle alarm, or bike-specific insurance for extra peace of mind.
         </p>
         <router-link to="/storage" target="_blank" class="find-shops-btn">
           Learn Bike Storage Tips <span class="chevron-right" aria-hidden="true"></span>

--- a/src/components/assessment/SavingsFaqSection.vue
+++ b/src/components/assessment/SavingsFaqSection.vue
@@ -39,7 +39,7 @@
       <div class="total-comparison">
         <p v-if="adjustedSavings > 0">
           Even if you spend <strong>$1,000/year</strong> on occasional rentals and ride-shares, that's still
-          <span class="highlight-amount"><strong>{{ formatCurrency(adjustedSavings) }}</strong></span>
+          <span class="highlight-amount"><strong>{{ Currency.format(adjustedSavings) }}</strong></span>
           less than the 5-year cost of car ownership!
         </p>
         <p v-else>
@@ -54,6 +54,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import Currency from '../../utils/currency';
 
 const props = defineProps({
   savingsAmount: { type: Number, required: true }
@@ -64,13 +65,6 @@ const adjustedSavings = computed(() => {
   return Math.floor(Math.max(0, netSavings) / 1000) * 1000;
 });
 
-function formatCurrency(value: number) {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    maximumFractionDigits: 0
-  }).format(value);
-}
 </script>
 
 <style lang="scss" scoped>

--- a/src/constants/assessmentOptions.ts
+++ b/src/constants/assessmentOptions.ts
@@ -68,8 +68,13 @@ export const StorageOptions: Record<string, AssessmentOption> = {
     description: 'Some stairs, but manageable'
   },
   'upper-floor': {
-    label: 'Upper Floor / No Storage',
+    label: 'Upper Floor',
     icon: '🪜',
-    description: 'Need to carry bike up stairs or lock outside'
+    description: 'Need to carry bike up stairs'
+  },
+  outdoor: {
+    label: 'Outdoor',
+    icon: '🌧️',
+    description: 'Locked outside with a cover'
   }
 };

--- a/src/constants/assessmentOptions.ts
+++ b/src/constants/assessmentOptions.ts
@@ -63,9 +63,9 @@ export const StorageOptions: Record<string, AssessmentOption> = {
     description: 'Dedicated ground-level space for bikes'
   },
   basement: {
-    label: 'Basement or a Few Steps',
+    label: 'Basement Or Up A Few Steps',
     icon: '🚪',
-    description: 'Some stairs, but manageable'
+    description: 'Some stairs, but manageable with a ramp'
   },
   'upper-floor': {
     label: 'Upper Floor',
@@ -75,6 +75,6 @@ export const StorageOptions: Record<string, AssessmentOption> = {
   outdoor: {
     label: 'Outdoor',
     icon: '🌧️',
-    description: 'Locked outside with a cover'
+    description: 'Locked outside with a cover (we can show you how)'
   }
 };

--- a/src/services/AssessmentForm.test.ts
+++ b/src/services/AssessmentForm.test.ts
@@ -94,7 +94,7 @@ describe('AssessmentForm decoding', () => {
   });
 
   it('returns null for invalid storage digit', () => {
-    expect(decodeProfile('1000001103')).toBeNull();
+    expect(decodeProfile('1000001109')).toBeNull();
   });
 
   it('returns null for empty string', () => {

--- a/src/services/AssessmentForm.ts
+++ b/src/services/AssessmentForm.ts
@@ -17,7 +17,7 @@ import type { AssessmentProfile, FitnessLevel, StorageType } from '../types';
  */
 
 const FitnessValues: FitnessLevel[] = ['low', 'medium', 'high'];
-const StorageValues: StorageType[] = ['garage', 'basement', 'upper-floor'];
+const StorageValues: StorageType[] = ['garage', 'basement', 'upper-floor', 'outdoor'];
 
 export function encodeProfile(profile: AssessmentProfile): string {
   const { transportationNeeds: t, geography: g } = profile;

--- a/src/services/BikeModelRecommender.test.ts
+++ b/src/services/BikeModelRecommender.test.ts
@@ -160,13 +160,13 @@ describe('BikeModelRecommender', () => {
       expect(recs[0].reasons).toContain('Handles hilly terrain');
     });
 
-    it('mentions storage downgrade', () => {
+    it('mentions storage alternate', () => {
       const r = makeRecommender(makeCargoProfile({
         fitnessLevel: 'medium',
         storage: 'upper-floor'
       }));
       const recs = r.getRecommendations();
-      expect(recs[0].reasons).toContain('Compact enough for upper-floor storage');
+      expect(recs[0].reasons).toContain('Easier-to-store alternative available');
     });
 
     it('mentions commuting for solo commuter with no cargo', () => {

--- a/src/services/BikeModelRecommender.ts
+++ b/src/services/BikeModelRecommender.ts
@@ -220,11 +220,11 @@ export default class BikeModelRecommender {
       reasons.push('No motor needed at your fitness level');
     }
 
-    const { idealBikeType } = new BikeTypeRecommender(this.profile);
-    if (idealBikeType) {
-      reasons.push('Compact enough for upper-floor storage');
+    const { alternateBikeType } = new BikeTypeRecommender(this.profile);
+    if (alternateBikeType) {
+      reasons.push('Easier-to-store alternative available');
     }
-    if (storage === 'garage') reasons.push('Plenty of storage space available');
+    if (storage === 'garage' || storage === 'outdoor') reasons.push('Plenty of storage space available');
     if (storage === 'upper-floor') reasons.push('Lightweight options prioritized for carrying upstairs');
     if (geography.hilly) reasons.push('Single-speed bikes excluded — not suited for hills');
 

--- a/src/services/BikeTypeRecommender.test.ts
+++ b/src/services/BikeTypeRecommender.test.ts
@@ -140,50 +140,68 @@ describe('BikeTypeRecommender', () => {
     });
   });
 
-  describe('storage downgrade', () => {
-    it('downgrades cargo-ebike to commuter-ebike for upper-floor storage', () => {
+  describe('storage alternate', () => {
+    it('suggests commuter-ebike as alternate for cargo-ebike with upper-floor storage', () => {
       const r = new BikeTypeRecommender(makeCargoProfile({
         fitnessLevel: 'medium',
         storage: 'upper-floor'
       }));
-      expect(r.bikeType).toBe('commuter-ebike');
-      expect(r.idealBikeType).toBe('cargo-ebike');
+      expect(r.bikeType).toBe('cargo-ebike');
+      expect(r.alternateBikeType).toBe('commuter-ebike');
     });
 
-    it('downgrades longtail-ebike to commuter-ebike for upper-floor storage', () => {
+    it('suggests commuter-ebike as alternate for longtail-ebike with upper-floor storage', () => {
       const r = new BikeTypeRecommender(makeLongtailProfile({
         fitnessLevel: 'medium',
         storage: 'upper-floor'
       }));
-      expect(r.bikeType).toBe('commuter-ebike');
-      expect(r.idealBikeType).toBe('longtail-ebike');
+      expect(r.bikeType).toBe('longtail-ebike');
+      expect(r.alternateBikeType).toBe('commuter-ebike');
     });
 
-    it('downgrades cargo-bike to regular-bike for upper-floor storage', () => {
+    it('suggests regular-bike as alternate for cargo-bike with upper-floor storage', () => {
       const r = new BikeTypeRecommender(makeCargoProfile({
         fitnessLevel: 'high',
         storage: 'upper-floor'
       }));
-      expect(r.bikeType).toBe('regular-bike');
-      expect(r.idealBikeType).toBe('cargo-bike');
+      expect(r.bikeType).toBe('cargo-bike');
+      expect(r.alternateBikeType).toBe('regular-bike');
     });
 
-    it('does not downgrade for garage storage', () => {
+    it('suggests alternate for basement storage', () => {
+      const r = new BikeTypeRecommender(makeCargoProfile({
+        fitnessLevel: 'medium',
+        storage: 'basement'
+      }));
+      expect(r.bikeType).toBe('cargo-ebike');
+      expect(r.alternateBikeType).toBe('commuter-ebike');
+    });
+
+    it('does not suggest alternate for garage storage', () => {
       const r = new BikeTypeRecommender(makeCargoProfile({
         fitnessLevel: 'medium',
         storage: 'garage'
       }));
       expect(r.bikeType).toBe('cargo-ebike');
-      expect(r.idealBikeType).toBeNull();
+      expect(r.alternateBikeType).toBeNull();
     });
 
-    it('does not downgrade non-bulky types for upper-floor', () => {
+    it('does not suggest alternate for outdoor storage', () => {
+      const r = new BikeTypeRecommender(makeCargoProfile({
+        fitnessLevel: 'medium',
+        storage: 'outdoor'
+      }));
+      expect(r.bikeType).toBe('cargo-ebike');
+      expect(r.alternateBikeType).toBeNull();
+    });
+
+    it('does not suggest alternate for non-bulky types with upper-floor', () => {
       const r = new BikeTypeRecommender(makeProfile({
         fitnessLevel: 'medium',
         storage: 'upper-floor'
       }));
       expect(r.bikeType).toBe('regular-bike');
-      expect(r.idealBikeType).toBeNull();
+      expect(r.alternateBikeType).toBeNull();
     });
   });
 });

--- a/src/services/BikeTypeRecommender.ts
+++ b/src/services/BikeTypeRecommender.ts
@@ -6,20 +6,22 @@ import type { AssessmentProfile, BikeTypeId } from '../types';
  *
  * Handles two layers:
  * 1. Picks the ideal type based on needs, geography, fitness, and stability preference.
- * 2. Applies a storage downgrade when the ideal type is too bulky for upper-floor storage.
+ * 2. When the ideal type is bulky and storage is constrained (not garage/outdoor),
+ *    sets an alternateBikeType — a smaller bike the user could consider instead.
+ *    The main recommendation always stays as the ideal bike.
  *
  * Usage:
  *   const recommender = new BikeTypeRecommender(profile);
- *   recommender.bikeType       // → 'commuter-ebike'
- *   recommender.idealBikeType  // → null (or original type if storage-downgraded)
+ *   recommender.bikeType          // → 'cargo-ebike' (always the ideal)
+ *   recommender.alternateBikeType // → 'commuter-ebike' (smaller option, or null)
  */
 export default class BikeTypeRecommender {
   bikeType: BikeTypeId;
-  idealBikeType: BikeTypeId | null;
+  alternateBikeType: BikeTypeId | null;
 
   constructor(profile: AssessmentProfile) {
     this.bikeType = this._determineBikeType(profile);
-    this.idealBikeType = this._applyStorageDowngrade(profile);
+    this.alternateBikeType = this._findAlternate(profile);
   }
 
   private _determineBikeType(profile: AssessmentProfile): BikeTypeId {
@@ -59,12 +61,11 @@ export default class BikeTypeRecommender {
            fitnessLevel === 'low';
   }
 
-  private _applyStorageDowngrade(profile: AssessmentProfile): BikeTypeId | null {
+  private _findAlternate(profile: AssessmentProfile): BikeTypeId | null {
     const typeInfo = BikeTypes[this.bikeType];
-    if (profile.storage === 'upper-floor' && typeInfo.bulky && typeInfo.storageDowngrade) {
-      const ideal = this.bikeType;
-      this.bikeType = typeInfo.storageDowngrade;
-      return ideal;
+    const hasEasyStorage = profile.storage === 'garage' || profile.storage === 'outdoor';
+    if (!hasEasyStorage && typeInfo.bulky && typeInfo.storageDowngrade) {
+      return typeInfo.storageDowngrade;
     }
     return null;
   }

--- a/src/services/storageTip.test.ts
+++ b/src/services/storageTip.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import StorageTip from './storageTip';
+
+describe('StorageTip.shouldShowBuyingTip', () => {
+  it('shows for bulky bike with basement storage', () => {
+    expect(StorageTip.shouldShowBuyingTip('cargo-ebike', 'basement')).toBe(true);
+  });
+
+  it('shows for bulky bike with upper-floor storage', () => {
+    expect(StorageTip.shouldShowBuyingTip('longtail-ebike', 'upper-floor')).toBe(true);
+  });
+
+  it('shows for bulky bike with outdoor storage', () => {
+    expect(StorageTip.shouldShowBuyingTip('cargo-ebike', 'outdoor')).toBe(true);
+  });
+
+  it('does not show for bulky bike with garage storage', () => {
+    expect(StorageTip.shouldShowBuyingTip('cargo-ebike', 'garage')).toBe(false);
+  });
+
+  it('does not show for non-bulky bike with any storage', () => {
+    expect(StorageTip.shouldShowBuyingTip('regular-bike', 'upper-floor')).toBe(false);
+    expect(StorageTip.shouldShowBuyingTip('commuter-ebike', 'basement')).toBe(false);
+  });
+});
+
+describe('StorageTip.shouldShowAlternateNote', () => {
+  it('shows for bulky bike with basement storage', () => {
+    expect(StorageTip.shouldShowAlternateNote('cargo-ebike', 'basement')).toBe(true);
+  });
+
+  it('shows for bulky bike with upper-floor storage', () => {
+    expect(StorageTip.shouldShowAlternateNote('longtail-ebike', 'upper-floor')).toBe(true);
+  });
+
+  it('does not show for bulky bike with outdoor storage', () => {
+    expect(StorageTip.shouldShowAlternateNote('cargo-ebike', 'outdoor')).toBe(false);
+  });
+
+  it('does not show for bulky bike with garage storage', () => {
+    expect(StorageTip.shouldShowAlternateNote('cargo-ebike', 'garage')).toBe(false);
+  });
+
+  it('does not show for non-bulky bike', () => {
+    expect(StorageTip.shouldShowAlternateNote('regular-bike', 'upper-floor')).toBe(false);
+  });
+});
+

--- a/src/services/storageTip.ts
+++ b/src/services/storageTip.ts
@@ -1,0 +1,20 @@
+import { BikeTypes } from '../constants/bikeTypes';
+import type { BikeTypeId, StorageType } from '../types';
+
+export default class StorageTip {
+  /** Whether to show the "Plan Your Storage" buying tip (bulky bike, no garage). */
+  static shouldShowBuyingTip(bikeType: BikeTypeId, storage: StorageType): boolean {
+    const isBulky = BikeTypes[bikeType]?.bulky ?? false;
+
+    return isBulky && storage !== 'garage';
+  }
+
+  /** Whether to show the alternate bike note (bulky bike, no easy storage). */
+  static shouldShowAlternateNote(bikeType: BikeTypeId, storage: StorageType): boolean {
+    const typeInfo = BikeTypes[bikeType];
+
+    if (!typeInfo?.bulky || !typeInfo.storageDowngrade) return false;
+
+    return storage !== 'garage' && storage !== 'outdoor';
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -73,7 +73,7 @@ export interface Geography {
 }
 
 export type FitnessLevel = 'low' | 'medium' | 'high';
-export type StorageType = 'garage' | 'basement' | 'upper-floor';
+export type StorageType = 'garage' | 'basement' | 'upper-floor' | 'outdoor';
 
 export interface AssessmentProfile {
   transportationNeeds: TransportationNeeds;

--- a/src/utils/currency.test.ts
+++ b/src/utils/currency.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import Currency from './currency';
+
+describe('Currency.format', () => {
+  it('formats a round number', () => {
+    expect(Currency.format(1234)).toBe('$1,234');
+  });
+
+  it('truncates decimals', () => {
+    expect(Currency.format(1234.56)).toBe('$1,235');
+  });
+
+  it('formats zero', () => {
+    expect(Currency.format(0)).toBe('$0');
+  });
+
+  it('formats negative values', () => {
+    expect(Currency.format(-500)).toBe('-$500');
+  });
+});
+
+describe('Currency.formatRounded', () => {
+  it('rounds to nearest $1k for values under $1M', () => {
+    expect(Currency.formatRounded(54_321)).toBe('$54,000');
+  });
+
+  it('rounds small values to nearest $1k', () => {
+    expect(Currency.formatRounded(1_500)).toBe('$2,000');
+  });
+
+  it('formats values at exactly $1M', () => {
+    expect(Currency.formatRounded(1_000_000)).toBe('$1 million');
+  });
+
+  it('formats values over $1M with one decimal', () => {
+    expect(Currency.formatRounded(1_500_000)).toBe('$1.5 million');
+  });
+
+  it('drops decimal when millions is whole', () => {
+    expect(Currency.formatRounded(2_000_000)).toBe('$2 million');
+  });
+});
+
+describe('Currency.investmentGrowth', () => {
+  it('returns the original amount at 0 years', () => {
+    expect(Currency.investmentGrowth(1000, 0.07, 0)).toBe(1000);
+  });
+
+  it('compounds correctly over 1 year', () => {
+    expect(Currency.investmentGrowth(1000, 0.07, 1)).toBeCloseTo(1070);
+  });
+
+  it('compounds correctly over 3 years', () => {
+    // 1000 × 1.07 × 1.07 × 1.07 = 1000 × 1.225043 = 1225.043
+    expect(Currency.investmentGrowth(1000, 0.07, 3)).toBeCloseTo(1225.04, 1);
+  });
+
+  it('returns 0 when amount is 0', () => {
+    expect(Currency.investmentGrowth(0, 0.07, 40)).toBe(0);
+  });
+});

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -1,0 +1,29 @@
+export default class Currency {
+  /** Formats a number as USD with no decimal places (e.g. "$1,234"). */
+  static format(value: number): string {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      maximumFractionDigits: 0
+    }).format(value);
+  }
+
+  /** Rounds to the nearest $1k below $1M, or "$X.XM" at/above $1M. */
+  static formatRounded(value: number): string {
+    if (value >= 1_000_000) {
+      const millions = Math.round(value / 100_000) / 10;
+      const formatted = millions % 1 === 0 ? millions.toFixed(0) : millions.toFixed(1);
+      return '$' + formatted + ' million';
+    }
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      maximumFractionDigits: 0
+    }).format(Math.round(value / 1000) * 1000);
+  }
+
+  /** Projects a value forward at a compound growth rate. */
+  static investmentGrowth(amount: number, rate: number, years: number): number {
+    return amount * Math.pow(1 + rate, years);
+  }
+}


### PR DESCRIPTION
Added a fourth "Outdoor" storage option to the storage options, and reworked the site to always recommend your ideal bike, pitching outdoor storage, but with an option to back out to a lighter alternate. This way we encourage folks to make the bike that's best for them work!

| Form Change | Results With Non Ideal Storage |
| --- | --- |
| <img width="1245" height="871" alt="image" src="https://github.com/user-attachments/assets/f2e26dda-2e7f-4f94-8611-0078fcd9e8b4" /> | <img width="1245" height="871" alt="image" src="https://github.com/user-attachments/assets/f2be4f01-e799-4e58-b21e-f2ce23cd1364" /> |

### Storage Page Updates

Updated the storage page with tips on GPS trackers & covers, closing #30.

**Left Is Before, Right is After**

<img width="1919" height="1174" alt="image" src="https://github.com/user-attachments/assets/480b609a-bda7-4ed6-bf34-c87576834fa2" />
